### PR TITLE
docs(spec): clarify provisioning resource ref form still valid

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,13 +294,26 @@
 
           <hr class="hr-dot-bold my-7">
           <h3 id="structure">Structure<a class="anchor" href="#structure"></a></h3>
-          <p>The CDS MUST consist of a single root document. All references (<code>$ref</code>) MUST be internal
-            references starting with <code>#/</code>; external file references are not supported.
-            The root file SHOULD be named 'clouddesign.json' or 'clouddesign.yaml'.
+          <p>The CDS MUST consist of a single root document. The root file SHOULD be named 'clouddesign.json' or 'clouddesign.yaml'.
             <br>
-            <small><em>Note: Earlier versions defined a "CDS snippet" mechanism for splitting a CDS into multiple
-            files via external references. This was deprecated in 2026-05; future cross-project references will be
-            provided via a project_id-based linking specification.</em></small>
+            References (<code>$ref</code>) take two forms:
+            <ul>
+              <li><b>CDS-internal reference</b> — points to a directive inside the same CDS document. Starts with
+                <code>#/</code> and describes the path from the CDS root (e.g. <code>#/actors/customer</code>,
+                <code>#/components/infoTypes/pii</code>, <code>#/contexts/web/trigger</code>).</li>
+              <li><b>Provisioning resource reference</b> — points to a specific resource declared inside a provisioning
+                file listed in the CDS <code>resources[]</code> array. Form is
+                <code>&lt;file&gt;#/&lt;section&gt;/&lt;RealKey&gt;</code> where <code>&lt;file&gt;</code> matches a
+                filename declared in <code>resources[]</code>, <code>&lt;section&gt;</code> is the lowercase section
+                indicator (<code>resources</code> for CFn / Terraform / etc., <code>functions</code> for Serverless
+                Framework Lambda), and <code>&lt;RealKey&gt;</code> is the actual key inside the provisioning file
+                (case-sensitive).</li>
+            </ul>
+            <small><em>Note: A "CDS snippet" mechanism for splitting a CDS document across multiple external files
+            was deprecated in 2026-05. Cross-CDS-file references are not supported; future cross-project references
+            will be provided via a project_id-based linking specification. Provisioning resource references
+            (<code>&lt;file&gt;#/&lt;section&gt;/&lt;RealKey&gt;</code>) remain valid — they are NOT cross-CDS-file
+            references but link a CDS to entries inside its declared provisioning files.</em></small>
             </p>
 
           <!--
@@ -1703,7 +1716,7 @@
         <span class="token tag">"$ref": </span>"#/actors/customer"
   },
   <span class="token tag">"end": </span>[
-        {<span class="token tag">"$ref": </span>"#/resources/awsCloudEnvironment/data/Resources/cloudFront"}
+        {<span class="token tag">"$ref": </span>"awsCloudEnvironment.yaml#/resources/cloudFront"}
   ],
   <span class="token tag">"endpointTitle": </span>{
     <span class="token tag">"en": </span>"LoadBalancer",
@@ -1742,7 +1755,7 @@
 <span class="token tag">start: </span>
       <span class="token tag">$ref: </span>#/actors/customer
 <span class="token tag">end: </span>
-      - <span class="token tag">$ref: </span>#/resources/awsCloudEnvironment/data/Resources/cloudFront
+      - <span class="token tag">$ref: </span>awsCloudEnvironment.yaml#/resources/cloudFront
 <span class="token tag">endpointTitle: </span>
       <span class="token tag">en: </span>LoadBalancer
       <span class="token tag">ja: </span>ロードバランサ
@@ -1929,7 +1942,7 @@
   <span class="token tag">"kbRequest": </span>{<code>"max":</code> 0.01, <code>"min":</code> 0.01},
   <span class="token tag">"kbResponse": </span>{<code>"max":</code> 1, <code>"min":</code> 1},
   <span class="token tag">"start": </span>{
-        <span class="token tag">"$ref": </span>"#/resources/awsCloudEnvironment/resources/jobServer"
+        <span class="token tag">"$ref": </span>"awsCloudEnvironment.yaml#/resources/jobServer"
   },
   <span class="token tag">"end": </span>[
         {<span class="token tag">"$ref": </span>"##/actors/api"}
@@ -1968,7 +1981,7 @@
 <span class="token tag">kbRequest: </span>{<code>max:</code> 0.01, <code>min:</code> 0.01}
 <span class="token tag">kbResponse: </span>{<code>max:</code> 1, <code>min:</code> 1}
 <span class="token tag">start: </span>
-      <span class="token tag">$ref: </span>#/resources/awsCloudEnvironment/resources/jobServer
+      <span class="token tag">$ref: </span>awsCloudEnvironment.yaml#/resources/jobServer
 <span class="token tag">end: </span>
       - <span class="token tag">$ref: </span>#/actors/api
 <span class="token tag">endpointTitle: </span>
@@ -2206,7 +2219,7 @@
   <span class="token tag">"restriction": </span>false,
   <span class="token tag">"source": </span>{<span class="token tag">"$ref": </span>"#/trigger/customer"},
   <span class="token tag">"end": </span>[
-        {<span class="token tag">"$ref": </span>"#/resources/awsCloudEnvironment/data/Resources/s3"}
+        {<span class="token tag">"$ref": </span>"awsCloudEnvironment.yaml#/resources/s3"}
   ],
   <span class="token tag">"passThroughReqRatio": </span>{<code>"max":</code> 1, <code>"min":</code> 0.1},
   <span class="token tag">"compositResRatio": </span>{<code>"max":</code> 0.5, <code>"min":</code> 0.5},
@@ -2241,7 +2254,7 @@
 <span class="token tag">source: </span>
       <span class="token tag">$ref: </span>#/trigger/customer
 <span class="token tag">end: </span>
-    - <span class="token tag">$ref: </span>#/resources/awsCloudEnvironment/data/Resources/s3
+    - <span class="token tag">$ref: </span>awsCloudEnvironment.yaml#/resources/s3
 <span class="token tag">passThroughReqRatio: </span>{<code>max:</code> 1, <code>min:</code> 0.1}
 <span class="token tag">compositResRatio: </span>{<code>max:</code> 0.5, <code>min:</code> 0.5}
 <span class="token tag">endpointTitle: </span>
@@ -2498,10 +2511,19 @@
             <div class="d-table-row">
               <p class="d-table-cell p-2 bg-white text-dark border">$ref</p>
               <p class="d-table-cell p-2 bg-white text-dark border"><code>string</code></p>
-              <p class="d-table-cell p-2 bg-white text-dark border"><strong>REQUIRED</strong>. Reference strings. MUST
-                be an internal reference starting with <code>#/</code>, describing the path from the CDS root object.
-                External file references (e.g. <code>other.json#/...</code>) are no longer supported (the CDS
-                Snippet feature was deprecated in 2026-05).
+              <p class="d-table-cell p-2 bg-white text-dark border"><strong>REQUIRED</strong>. Reference string. Two
+                forms:
+                <ul>
+                  <li><b>CDS-internal</b>: starts with <code>#/</code> and describes the path from the CDS root
+                    (e.g. <code>#/actors/customer</code>, <code>#/components/infoTypes/pii</code>).</li>
+                  <li><b>Provisioning resource</b>: <code>&lt;file&gt;#/&lt;section&gt;/&lt;RealKey&gt;</code> where
+                    <code>&lt;file&gt;</code> is a filename declared in CDS <code>resources[]</code> with extension,
+                    <code>&lt;section&gt;</code> is <code>resources</code> (CFn / Terraform / GDM / CIM / ARM / ROS) or
+                    <code>functions</code> (Serverless Framework Lambda), and <code>&lt;RealKey&gt;</code> is the
+                    resource's actual key inside the provisioning file (case-sensitive).</li>
+                </ul>
+                Cross-CDS-file references (the deprecated "CDS Snippet" form, e.g.
+                <code>other.json#/actors/x</code>) are NOT supported.
               </p>
             </div>
           </div>
@@ -2664,6 +2686,19 @@
                 (<code>&lt;file&gt;.<i>ext</i>#/...</code>). All <code>$ref</code> values MUST now be
                 internal-only (<code>#/...</code>). Future cross-project references will be added as a separate
                 project_id-based linking specification (no schema impact yet).
+              </p>
+            </div>
+            <div class="d-table-row">
+              <p class="d-table-cell p-2 bg-white text-dark border">1.3.2(clarification)</p>
+              <p class="d-table-cell p-2 bg-white text-dark border">2026-05-11</p>
+              <p class="d-table-cell p-2 bg-white text-dark border">
+                Clarified scope of the 2026-05-08 deprecation: only <strong>cross-CDS-file</strong> references
+                (the "CDS Snippet" mechanism) are deprecated. <strong>Provisioning resource references</strong>
+                — pointing from a CDS to entries inside provisioning files declared in
+                <code>resources[]</code> — use the form <code>&lt;file&gt;#/&lt;section&gt;/&lt;RealKey&gt;</code>
+                and remain valid. <code>&lt;section&gt;</code> is the lowercase section indicator
+                (<code>resources</code> or <code>functions</code>). Documentation, schema, and code examples
+                updated to use this form consistently.
               </p>
             </div>
           </div>

--- a/index_ja.html
+++ b/index_ja.html
@@ -275,10 +275,14 @@
 
           <hr class="hr-dot-bold my-7">
           <h3 id="structure">構造<a class="anchor" href="#structure"></a></h3>
-          <p>CDSは単一のルート文書である必要があります。すべての参照 (<code>$ref</code>) は <code>#/</code> で始まる内部参照のみで、外部ファイル参照はサポートされません。
-            ルートファイルは 'clouddesign.json' か 'clouddesign.yaml' という命名にすべきです。
+          <p>CDSは単一のルート文書である必要があります。ルートファイルは 'clouddesign.json' か 'clouddesign.yaml' という命名にすべきです。
             <br>
-            <small><em>注: 旧バージョンでは CDS を複数ファイルに分割するための「CDSスニペット」機構が定義されていましたが、2026-05 に廃止されました。プロジェクト横断参照は将来的に project_id ベースの新仕様で提供予定です。</em></small>
+            参照 (<code>$ref</code>) は次の 2 種類があります:
+            <ul>
+              <li><b>CDS内部参照</b> — 同一 CDS 内のディレクティブを指す。<code>#/</code> で始まり CDS root からのパスを記述 (例 <code>#/actors/customer</code>、<code>#/components/infoTypes/pii</code>、<code>#/contexts/web/trigger</code>)</li>
+              <li><b>provisioning リソース参照</b> — CDS の <code>resources[]</code> に列挙された provisioning ファイル内のリソースを指す。形式は <code>&lt;file&gt;#/&lt;section&gt;/&lt;RealKey&gt;</code>。<code>&lt;file&gt;</code> は <code>resources[]</code> に宣言したファイル名 (拡張子付き)、<code>&lt;section&gt;</code> は固定の小文字セクション識別子 (<code>resources</code> = CFn / Terraform / GDM / CIM / ARM / ROS、<code>functions</code> = Serverless Framework Lambda)、<code>&lt;RealKey&gt;</code> は provisioning ファイル内の実キー (大小文字区別あり)</li>
+            </ul>
+            <small><em>注: CDS を複数の外部ファイルに分割する「CDSスニペット」機構は 2026-05 に廃止されました。CDS 間のクロスファイル参照はサポートされません。プロジェクト横断の参照は将来的に project_id ベースの新仕様で提供予定です。provisioning リソース参照 (<code>&lt;file&gt;#/&lt;section&gt;/&lt;RealKey&gt;</code>) は CDS 間参照ではなく、CDS と自身が宣言する provisioning ファイル内エントリの紐付けなので引き続き有効です。</em></small>
             </p>
           </div>
           <hr class="hr-dot-bold my-7">
@@ -1599,7 +1603,7 @@
         <span class="token tag">"$ref": </span>"#/actors/customer"
   },
   <span class="token tag">"end": </span>[
-        {<span class="token tag">"$ref": </span>"#/resources/awsCloudEnvironment/data/Resources/cloudFront"}
+        {<span class="token tag">"$ref": </span>"awsCloudEnvironment.yaml#/resources/cloudFront"}
   ],
   <span class="token tag">"endpointTitle": </span>{
     <span class="token tag">"en": </span>"LoadBalancer",
@@ -1638,7 +1642,7 @@
 <span class="token tag">start: </span>
       <span class="token tag">$ref: </span>#/actors/customer
 <span class="token tag">end: </span>
-      - <span class="token tag">$ref: </span>#/resources/awsCloudEnvironment/data/Resources/cloudFront
+      - <span class="token tag">$ref: </span>awsCloudEnvironment.yaml#/resources/cloudFront
 <span class="token tag">endpointTitle: </span>
       <span class="token tag">en: </span>LoadBalancer
       <span class="token tag">ja: </span>ロードバランサ
@@ -1814,7 +1818,7 @@
   <span class="token tag">"kbRequest": </span>{<code>"max":</code> 0.01, <code>"min":</code> 0.01},
   <span class="token tag">"kbResponse": </span>{<code>"max":</code> 1, <code>"min":</code> 1},
   <span class="token tag">"start": </span>{
-        <span class="token tag">"$ref": </span>"#/resources/awsCloudEnvironment/resources/jobServer"
+        <span class="token tag">"$ref": </span>"awsCloudEnvironment.yaml#/resources/jobServer"
   },
   <span class="token tag">"end": </span>[
         {<span class="token tag">"$ref": </span>"##/actors/api"}
@@ -1853,7 +1857,7 @@
 <span class="token tag">kbRequest: </span>{<code>max:</code> 0.01, <code>min:</code> 0.01}
 <span class="token tag">kbResponse: </span>{<code>max:</code> 1, <code>min:</code> 1}
 <span class="token tag">start: </span>
-      <span class="token tag">$ref: </span>#/resources/awsCloudEnvironment/resources/jobServer
+      <span class="token tag">$ref: </span>awsCloudEnvironment.yaml#/resources/jobServer
 <span class="token tag">end: </span>
       - <span class="token tag">$ref: </span>#/actors/api
 <span class="token tag">endpointTitle: </span>
@@ -2070,7 +2074,7 @@
   <span class="token tag">"restriction": </span>false,
   <span class="token tag">"source": </span>{<span class="token tag">"$ref": </span>"#/trigger/customer"},
   <span class="token tag">"end": </span>[
-        {<span class="token tag">"$ref": </span>"#/resources/awsCloudEnvironment/data/Resources/s3"}
+        {<span class="token tag">"$ref": </span>"awsCloudEnvironment.yaml#/resources/s3"}
   ],
   <span class="token tag">"passThroughReqRatio": </span>{<code>"max":</code> 1, <code>"min":</code> 0.1},
   <span class="token tag">"compositResRatio": </span>{<code>"max":</code> 0.5, <code>"min":</code> 0.5},
@@ -2105,7 +2109,7 @@
 <span class="token tag">source: </span>
       <span class="token tag">$ref: </span>#/trigger/customer
 <span class="token tag">end: </span>
-    - <span class="token tag">$ref: </span>#/resources/awsCloudEnvironment/data/Resources/s3
+    - <span class="token tag">$ref: </span>awsCloudEnvironment.yaml#/resources/s3
 <span class="token tag">passThroughReqRatio: </span>{<code>max:</code> 1, <code>min:</code> 0.1}
 <span class="token tag">compositResRatio: </span>{<code>max:</code> 0.5, <code>min:</code> 0.5}
 <span class="token tag">endpointTitle: </span>
@@ -2357,9 +2361,12 @@
             <div class="d-table-row">
               <p class="d-table-cell p-2 bg-white text-dark border">$ref</p>
               <p class="d-table-cell p-2 bg-white text-dark border"><code>string</code></p>
-              <p class="d-table-cell p-2 bg-white text-dark border"><strong>必須</strong>. 参照文字列。
-                <code>#/</code>で始まる内部参照のみを記述し、CDSのルートオブジェクトからのパスを記述します。
-                外部ファイル参照（例 <code>other.json#/...</code>）はサポートされません（CDSスニペット機能は2026-05に廃止）。
+              <p class="d-table-cell p-2 bg-white text-dark border"><strong>必須</strong>. 参照文字列。次の 2 形式:
+                <ul>
+                  <li><b>CDS 内部参照</b>: <code>#/</code> で始まり CDS root からのパス (例 <code>#/actors/customer</code>、<code>#/components/infoTypes/pii</code>)</li>
+                  <li><b>provisioning リソース参照</b>: <code>&lt;file&gt;#/&lt;section&gt;/&lt;RealKey&gt;</code>。<code>&lt;file&gt;</code> は CDS <code>resources[]</code> で宣言したファイル名 (拡張子付き)、<code>&lt;section&gt;</code> は <code>resources</code> (CFn / Terraform / GDM / CIM / ARM / ROS) または <code>functions</code> (Serverless Framework Lambda)、<code>&lt;RealKey&gt;</code> は provisioning ファイル内の実キー (大小文字区別あり)</li>
+                </ul>
+                CDS 間のクロスファイル参照 (旧「CDSスニペット」形式、例 <code>other.json#/actors/x</code>) はサポートされません。
               </p>
             </div>
           </div>
@@ -2518,6 +2525,16 @@
                 （<code>&lt;file&gt;.<i>ext</i>#/...</code> 形式の <code>$ref</code> はサポート停止）。
                 以降、すべての <code>$ref</code> は <code>#/...</code> 内部参照のみとなります。
                 プロジェクト横断でリソースやアクターを参照する用途は、将来的に project_id ベースのリンク仕様を別途追加予定です（本スキーマには未影響）。
+              </p>
+            </div>
+            <div class="d-table-row">
+              <p class="d-table-cell p-2 bg-white text-dark border">1.3.2(補足)</p>
+              <p class="d-table-cell p-2 bg-white text-dark border">2026-05-11</p>
+              <p class="d-table-cell p-2 bg-white text-dark border">
+                2026-05-08 の廃止対象を明確化: 廃止されたのは <strong>CDS 間のクロスファイル参照</strong>（旧「CDSスニペット」機構）のみ。
+                <strong>provisioning リソース参照</strong>（CDS から自身が <code>resources[]</code> で宣言する provisioning ファイル内エントリへのリンク）は引き続き有効で、形式は <code>&lt;file&gt;#/&lt;section&gt;/&lt;RealKey&gt;</code> です。
+                <code>&lt;section&gt;</code> は小文字固定のセクション識別子 (<code>resources</code> または <code>functions</code>)。
+                ドキュメント、スキーマ、コード例をこの形式に統一しました。
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Problem

PR #3 (commit 4a70f18) で「外部ファイル参照は廃止」と書いたが、廃止対象が広すぎた。

実際に廃止されるべきだったのは **CDS 間のクロスファイル参照** (CDS Snippet 機構) のみ。
**CDS と自身が \`resources[]\` で宣言する provisioning ファイル内エントリへの参照**
(\`<file>#/<section>/<RealKey>\` 形式) は Conccent renderer がリソース解決に使う唯一の形式なので、
これを廃止と書いたことで PR #3 以降に作成された設計 (例: MARPH d603) が renderer 側で全アイコン
\`?\` 状態になっていた。

## Fix

- 構造 / Reference object 説明: 2 形式を明示 (CDS 内部 \`#/...\` と provisioning リソース \`<file>#/<section>/<RealKey>\`)
- 大文字小文字の規約: \`/resources/\` \`/functions/\` は小文字固定、\`<RealKey>\` は provisioning ファイルそのまま
- 例コード 6 箇所 (en/ja 各 JSON/YAML 各 3 件): \`#/resources/<file>/data/Resources/<key>\` を \`<file>.yaml#/resources/<key>\` に変更
- 新 revision entry (2026-05-11) で廃止スコープを明確化

並行 PR (mcp-server #33/#34) で MCP guide / schema も同形式に揃え済み。